### PR TITLE
Fix missing closing parentheses in README.md for beer_contract

### DIFF
--- a/beer_contracts/README.adoc
+++ b/beer_contracts/README.adoc
@@ -48,7 +48,7 @@ Example for Maven
     <artifactId>spring-cloud-contract-maven-plugin</artifactId>
     <configuration>
         <!-- url not required for working locally -->
-        <contractsWorkOffline>true<contractsWorkOffline>
+        <contractsWorkOffline>true</contractsWorkOffline>
         <contractDependency>
             <groupId>com.example</groupId>
             <artifactId>beer-contracts</artifactId>


### PR DESCRIPTION
Hi,

I noticed there's a missing parentheses for the readme in beer_contract, so I added it. Hope this could be useful.

Ping me if there's anything I need to add for this.

Cheers.