### PR TITLE
spring cloud contract producer tests fail for messages, if

### DIFF
--- a/producer/src/main/java/com/example/ProducerApplication.java
+++ b/producer/src/main/java/com/example/ProducerApplication.java
@@ -3,10 +3,10 @@ package com.example;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.stream.annotation.EnableBinding;
-import org.springframework.cloud.stream.messaging.Source;
+import org.springframework.cloud.stream.messaging.Processor;
 
 @SpringBootApplication
-@EnableBinding(Source.class)
+@EnableBinding(Processor.class)
 public class ProducerApplication {
 
 	public static void main(String[] args) {

--- a/producer/src/main/resources/application.yml
+++ b/producer/src/main/resources/application.yml
@@ -1,6 +1,12 @@
 spring:
     application.name: beer-api-producer
-    cloud.stream.bindings.output:
+    cloud.stream.bindings:
+      output:
+        content-type: application/json
+        # remove::start[]
+        destination: verifications
+        # remove::end[]
+      input:
         content-type: application/json
         # remove::start[]
         destination: verifications


### PR DESCRIPTION
there is an input channel for the output channel verified in the
contract.

`./gradlew clean generateContractTests test`