### PR TITLE
URL Cleanup

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -8,7 +8,7 @@
 <title>Spring Cloud Contract Samples</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Remove comment around @import statement below when using as a custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}

--- a/docs/tutorials/contracts_external.adoc
+++ b/docs/tutorials/contracts_external.adoc
@@ -384,7 +384,7 @@ following snippet:
             <artifactId>beer-contracts</artifactId>
         </contractDependency>
         <!-- The JAR with contracts will get downloaded from an external repo -->
-        <contractsRepositoryUrl>http://foo.bar/baz</contractsRepositoryUrl>
+        <contractsRepositoryUrl>https://foo.bar/baz</contractsRepositoryUrl>
         <!-- Base package for generated tests -->
         <basePackageForTests>com.example</basePackageForTests>
     </configuration>
@@ -400,7 +400,7 @@ contracts {
 		stringNotation = 'com.example:beer-contracts'
 	}
 	// The JAR with contracts will get downloaded from an external repo
-	contractsRepositoryUrl = "http://foo.bar/baz"
+	contractsRepositoryUrl = "https://foo.bar/baz"
 	// Base package for generated tests
 	basePackageForTests = "com.example"
 	baseClassMappings {

--- a/docs/tutorials/contracts_external.html
+++ b/docs/tutorials/contracts_external.html
@@ -8,7 +8,7 @@
 <title>Contracts in an external repository</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Remove comment around @import statement below when using as a custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
@@ -1254,7 +1254,7 @@ Gradle. In this tutorial, we use Maven. You can see how the <code>pom.xml</code>
 <div class="listingblock">
 <div class="content">
 <pre class="prettyprint highlight"><code class="language-xml" data-lang="xml">&lt;project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
 	&lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
 
 	&lt;groupId&gt;com.example&lt;/groupId&gt;
@@ -2239,7 +2239,7 @@ following snippet:</p>
             &lt;artifactId&gt;beer-contracts&lt;/artifactId&gt;
         &lt;/contractDependency&gt;
         &lt;!-- The JAR with contracts will get downloaded from an external repo --&gt;
-        &lt;contractsRepositoryUrl&gt;http://foo.bar/baz&lt;/contractsRepositoryUrl&gt;
+        &lt;contractsRepositoryUrl&gt;https://foo.bar/baz&lt;/contractsRepositoryUrl&gt;
         &lt;!-- Base package for generated tests --&gt;
         &lt;basePackageForTests&gt;com.example&lt;/basePackageForTests&gt;
     &lt;/configuration&gt;
@@ -2258,7 +2258,7 @@ following snippet:</p>
 		stringNotation = 'com.example:beer-contracts'
 	}
 	// The JAR with contracts will get downloaded from an external repo
-	contractsRepositoryUrl = "http://foo.bar/baz"
+	contractsRepositoryUrl = "https://foo.bar/baz"
 	// Base package for generated tests
 	basePackageForTests = "com.example"
 	baseClassMappings {
@@ -2299,7 +2299,7 @@ code) it&#8217;s enough to remove the <code>workOffline</code> flag and to pass 
 @AutoConfigureMockMvc
 @AutoConfigureJsonTesters
 @AutoConfigureStubRunner(
-repositoryRoot="http://foo.com/bar,
+repositoryRoot="http://www.foo.com/bar,
 ids = "com.example:beer-api-producer-external:+:stubs:8090")
 @DirtiesContext
 public class YourTestOnTheConsumerSide extends AbstractTest {

--- a/docs/tutorials/contracts_on_the_producer_side.html
+++ b/docs/tutorials/contracts_on_the_producer_side.html
@@ -8,7 +8,7 @@
 <title>Contracts on the Producer Side</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Remove comment around @import statement below when using as a custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
@@ -2018,7 +2018,7 @@ code) it&#8217;s enough to remove the <code>workOffline</code> flag and to pass 
 @AutoConfigureMockMvc
 @AutoConfigureJsonTesters
 @AutoConfigureStubRunner(
-repositoryRoot="http://foo.com/bar,
+repositoryRoot="http://www.foo.com/bar,
 ids = "com.example:beer-api-producer:+:stubs:8090")
 @DirtiesContext
 public class YourTestOnTheConsumerSide extends AbstractTest {

--- a/docs/tutorials/contracts_representing_scenarios.html
+++ b/docs/tutorials/contracts_representing_scenarios.html
@@ -8,7 +8,7 @@
 <title>Contracts Representing Scenarios (Stateful Stubs)</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Remove comment around @import statement below when using as a custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
@@ -1439,7 +1439,7 @@ code) it&#8217;s enough to remove the <code>workOffline</code> flag and to pass 
 @AutoConfigureMockMvc
 @AutoConfigureJsonTesters
 @AutoConfigureStubRunner(
-repositoryRoot="http://foo.com/bar,
+repositoryRoot="http://www.foo.com/bar,
 ids = "com.example:beer-api-producer:+:stubs:8090")
 @DirtiesContext
 public class YourTestOnTheConsumerSide extends AbstractTest {

--- a/docs/tutorials/junit_rule.html
+++ b/docs/tutorials/junit_rule.html
@@ -8,7 +8,7 @@
 <title>Using JUnit rule</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Remove comment around @import statement below when using as a custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}

--- a/docs/tutorials/library_with_common_code.html
+++ b/docs/tutorials/library_with_common_code.html
@@ -8,7 +8,7 @@
 <title>Library with common code</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Remove comment around @import statement below when using as a custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}

--- a/docs/tutorials/rest_docs.html
+++ b/docs/tutorials/rest_docs.html
@@ -8,7 +8,7 @@
 <title>Spring Cloud Contract with Rest Docs</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Remove comment around @import statement below when using as a custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}

--- a/docs/tutorials/snippets/consumer_flow_2.adoc
+++ b/docs/tutorials/snippets/consumer_flow_2.adoc
@@ -15,7 +15,7 @@ code) it's enough to remove the `workOffline` flag and to pass the `repositoryRo
 @AutoConfigureMockMvc
 @AutoConfigureJsonTesters
 @AutoConfigureStubRunner(
-repositoryRoot="http://foo.com/bar,
+repositoryRoot="http://www.foo.com/bar,
 ids = "com.example:{producer_artifact}:+:stubs:8090")
 @DirtiesContext
 public class YourTestOnTheConsumerSide extends AbstractTest {

--- a/docs/tutorials/spring_cloud_contract_advanced.html
+++ b/docs/tutorials/spring_cloud_contract_advanced.html
@@ -8,7 +8,7 @@
 <title>Spring Cloud Contract Advanced</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Remove comment around @import statement below when using as a custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}

--- a/docs/tutorials/stub_runner_boot.adoc
+++ b/docs/tutorials/stub_runner_boot.adoc
@@ -134,7 +134,7 @@ We should get a `STOUT` string on the terminal.
 
 TIP: There are also  `/trigger` endpoints available if you want to trigger some messaging
 labels. You can read more about them in the https://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html#_stub_runner_boot_application[docs].
-For the http://cloud.spring.io/spring-cloud-pipelines/spring-cloud-pipelines.html[Spring
+For the https://cloud.spring.io/spring-cloud-pipelines/spring-cloud-pipelines.html[Spring
 Cloud Pipelines] project, we have a Stub Runner Boot application that uses a real
 instance of RabbitMQ for messaging and registers stubs in Eureka. You can check the code
 https://github.com/spring-cloud-samples/github-analytics-stub-runner-boot[here].

--- a/docs/tutorials/stub_runner_boot.html
+++ b/docs/tutorials/stub_runner_boot.html
@@ -8,7 +8,7 @@
 <title>Stub Runner Boot</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Remove comment around @import statement below when using as a custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
@@ -691,7 +691,7 @@ curl "localhost:${STUB_PORT}/stout"</code></pre>
 <td class="content">
 There are also  <code>/trigger</code> endpoints available if you want to trigger some messaging
 labels. You can read more about them in the <a href="https://cloud.spring.io/spring-cloud-contract/spring-cloud-contract.html#_stub_runner_boot_application">docs</a>.
-For the <a href="http://cloud.spring.io/spring-cloud-pipelines/spring-cloud-pipelines.html">Spring
+For the <a href="https://cloud.spring.io/spring-cloud-pipelines/spring-cloud-pipelines.html">Spring
 Cloud Pipelines</a> project, we have a Stub Runner Boot application that uses a real
 instance of RabbitMQ for messaging and registers stubs in Eureka. You can check the code
 <a href="https://github.com/spring-cloud-samples/github-analytics-stub-runner-boot">here</a>.

--- a/docs/tutorials/stubbing_out_service_discovery.html
+++ b/docs/tutorials/stubbing_out_service_discovery.html
@@ -8,7 +8,7 @@
 <title>Contracts on the Producer side</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Remove comment around @import statement below when using as a custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
@@ -1134,7 +1134,7 @@ code) it&#8217;s enough to remove the <code>workOffline</code> flag and to pass 
 @AutoConfigureMockMvc
 @AutoConfigureJsonTesters
 @AutoConfigureStubRunner(
-repositoryRoot="http://foo.com/bar,
+repositoryRoot="http://www.foo.com/bar,
 ids = "com.example:beer-api-producer:+:stubs:8090")
 @DirtiesContext
 public class YourTestOnTheConsumerSide extends AbstractTest {

--- a/docs/tutorials/stubs_per_consumer.html
+++ b/docs/tutorials/stubs_per_consumer.html
@@ -8,7 +8,7 @@
 <title>Contracts on the Producer Side</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Remove comment around @import statement below when using as a custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
@@ -1782,7 +1782,7 @@ code) it&#8217;s enough to remove the <code>workOffline</code> flag and to pass 
 @AutoConfigureMockMvc
 @AutoConfigureJsonTesters
 @AutoConfigureStubRunner(
-repositoryRoot="http://foo.com/bar,
+repositoryRoot="http://www.foo.com/bar,
 ids = "com.example:beer-api-producer-with-stubs-per-consumer:+:stubs:8090")
 @DirtiesContext
 public class YourTestOnTheConsumerSide extends AbstractTest {

--- a/docs/workshops.html
+++ b/docs/workshops.html
@@ -8,7 +8,7 @@
 <title>Spring Cloud Contract Workshops</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Remove comment around @import statement below when using as a custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://groovy-lang.org/json.html (200) with 5 occurrences could not be migrated:  
   ([https](https://groovy-lang.org/json.html) result SSLProtocolException).
* [ ] http://rest-assured.io/ (200) with 5 occurrences could not be migrated:  
   ([https](https://rest-assured.io/) result SSLHandshakeException).
* [ ] http://wiremock.org (200) with 8 occurrences could not be migrated:  
   ([https](https://wiremock.org) result SSLHandshakeException).
* [ ] http://foo.com/bar (301) with 6 occurrences could not be migrated:  
   ([https](https://foo.com/bar) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://foo.bar/baz (UnknownHostException) with 3 occurrences migrated to:  
  https://foo.bar/baz ([https](https://foo.bar/baz) result UnknownHostException).
* [ ] http://foo.bar/baz&lt;/contractsRepositoryUrl&gt (UnknownHostException) with 1 occurrences migrated to:  
  https://foo.bar/baz&lt;/contractsRepositoryUrl&gt ([https](https://foo.bar/baz&lt;/contractsRepositoryUrl&gt) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://asciidoctor.org with 12 occurrences migrated to:  
  https://asciidoctor.org ([https](https://asciidoctor.org) result 200).
* [ ] http://cloud.spring.io/spring-cloud-pipelines/spring-cloud-pipelines.html with 2 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-pipelines/spring-cloud-pipelines.html ([https](https://cloud.spring.io/spring-cloud-pipelines/spring-cloud-pipelines.html) result 200).
* [ ] http://maven.apache.org/xsd/maven-4.0.0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 14 occurrences
* http://localhost:8090/ with 14 occurrences
* http://localhost:8090/check with 5 occurrences
* http://localhost:9090/check with 2 occurrences
* http://maven.apache.org/POM/4.0.0 with 2 occurrences
* http://somenameforproducer/check with 8 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 1 occurrences