### PR TITLE
Fix Update Gradle Wrapper workflow.

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - run: cd common && ./gradlew clean build publishToMavenLocal
+
       - name: Update Gradle Wrapper
         uses: gradle-update/update-gradle-wrapper-action@v1
         with:


### PR DESCRIPTION
The action introduced in https://github.com/spring-cloud-samples/spring-cloud-contract-samples/pull/158 can't build correctly because of the current workflow setup.

In fact, the Update Gradle Wrapper action requires the project(s) to be in a buildable state to be able to update the Wrapper script.

In this PR we add a preliminary step which builds and publish locally the `common` artifact, which is shared across many projects.