### PR TITLE
Adds Kafka message key to 'producer_kafka' and 'consumer_kafka' samples

### DIFF
--- a/consumer_kafka/src/main/java/com/example/Application.java
+++ b/consumer_kafka/src/main/java/com/example/Application.java
@@ -23,52 +23,34 @@ import org.slf4j.LoggerFactory;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.kafka.ConcurrentKafkaListenerContainerFactoryConfigurer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.kafka.annotation.KafkaListener;
-import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
-import org.springframework.kafka.core.ConsumerFactory;
-import org.springframework.kafka.core.KafkaTemplate;
-import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
-import org.springframework.kafka.listener.SeekToCurrentErrorHandler;
 import org.springframework.kafka.support.converter.RecordMessageConverter;
 import org.springframework.kafka.support.converter.StringJsonMessageConverter;
-import org.springframework.util.backoff.BackOff;
-import org.springframework.util.backoff.FixedBackOff;
+import org.springframework.messaging.Message;
 
 /**
- *
  * @author Gary Russell
+ * @author Chris Bono
  * @since 2.2.1
- *
  */
 @SpringBootApplication
 public class Application {
 
 	private final Logger logger = LoggerFactory.getLogger(Application.class);
 
+	Foo2 storedFoo;
+
+	Message<Foo2> storedFooMessage;
+
 	public static void main(String[] args) {
 		SpringApplication.run(Application.class, args);
-	}
-
-	@Bean
-	public ConcurrentKafkaListenerContainerFactory<?, ?> kafkaListenerContainerFactory(
-			ConcurrentKafkaListenerContainerFactoryConfigurer configurer,
-			ConsumerFactory<Object, Object> kafkaConsumerFactory,
-			KafkaTemplate<Object, Object> template) {
-		ConcurrentKafkaListenerContainerFactory<Object, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
-		configurer.configure(factory, kafkaConsumerFactory);
-		factory.setErrorHandler(new SeekToCurrentErrorHandler(
-				new DeadLetterPublishingRecoverer(template), new FixedBackOff(3L, 3L))); // dead-letter after 3 tries
-		return factory;
 	}
 
 	@Bean
 	public RecordMessageConverter converter() {
 		return new StringJsonMessageConverter();
 	}
-
-	Foo2 storedFoo;
 
 	@KafkaListener(id = "fooGroup", topics = "topic1")
 	public void listen(Foo2 foo) {
@@ -79,19 +61,14 @@ public class Application {
 		this.storedFoo = foo;
 	}
 
-	@KafkaListener(id = "dltGroup", topics = "topic1.DLT")
-	public void dltListen(String in) {
-		logger.info("Received from DLT: " + in);
+	@KafkaListener(id = "fooMessageGroup", topics = "topic1")
+	public void listenFooMessage(Message<Foo2> fooMessage) {
+		logger.info("Received: " + fooMessage);
+		this.storedFooMessage = fooMessage;
 	}
 
 	@Bean
 	public NewTopic topic() {
 		return new NewTopic("topic1", 1, (short) 1);
 	}
-
-	@Bean
-	public NewTopic dlt() {
-		return new NewTopic("topic1.DLT", 1, (short) 1);
-	}
-
 }

--- a/consumer_kafka/src/main/resources/application.yml
+++ b/consumer_kafka/src/main/resources/application.yml
@@ -1,4 +1,8 @@
 spring:
   kafka:
-    producer:
-      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+    consumer:
+      group-id: groupId
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        "spring.json.trusted.packages": "*"

--- a/consumer_kafka/src/test/java/com/example/ApplicationTests.java
+++ b/consumer_kafka/src/test/java/com/example/ApplicationTests.java
@@ -48,7 +48,7 @@ public class ApplicationTests {
 	Application application;
 
 	@Test
-	public void contextLoads() {
+	public void consumesFooAsObject() {
 		this.trigger.trigger("trigger");
 
 		Awaitility.await().untilAsserted(() -> {
@@ -56,6 +56,20 @@ public class ApplicationTests {
 			BDDAssertions.then(this.application.storedFoo.getFoo()).contains("example");
 		});
 	}
+
+	@Test
+	public void consumesFooAsMessage() {
+		this.trigger.trigger("triggerMessage");
+
+		Awaitility.await().untilAsserted(() -> {
+			BDDAssertions.then(this.application.storedFooMessage).isNotNull();
+			BDDAssertions.then(this.application.storedFooMessage.getPayload().getFoo()).contains("example");
+			BDDAssertions.then(this.application.storedFooMessage.getHeaders().containsKey("kafka_receivedMessageKey"));
+			BDDAssertions.then(this.application.storedFooMessage.getHeaders().get("kafka_receivedMessageKey"))
+					.isEqualTo("key-example");
+		});
+	}
+
 	// remove::end[]
 
 }

--- a/consumer_kafka/src/test/resources/application-test.yml
+++ b/consumer_kafka/src/test/resources/application-test.yml
@@ -1,8 +1,6 @@
 spring:
   kafka:
     bootstrap-servers: ${spring.embedded.kafka.brokers}
-    consumer:
-      properties:
-        "key.serializer": "org.springframework.kafka.support.serializer.JsonSerializer"
-        "key.deserializer": "org.springframework.kafka.support.serializer.JsonDeserializer"
-      group-id: groupId
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer

--- a/producer_kafka/src/main/java/com/example/Controller.java
+++ b/producer_kafka/src/main/java/com/example/Controller.java
@@ -16,16 +16,23 @@
 
 package com.example;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import com.common.Foo1;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.common.Foo1;
-
 /**
  * @author Gary Russell
+ * @author Chris Bono
  * @since 2.2.1
  */
 @RestController
@@ -37,6 +44,15 @@ public class Controller {
 	@PostMapping(path = "/send/foo/{what}")
 	public void sendFoo(@PathVariable String what) {
 		this.template.send("topic1", new Foo1(what));
+	}
+
+	@PostMapping(path = "/send/foo/message/{what}")
+	public void sendFooAsMessage(@PathVariable String what) {
+		Map<String, Object> headers = new HashMap<>();
+		headers.put("kafka_topic", "topic1");
+		headers.put("kafka_messageKey", "key-" + what);
+		Message<Foo1> message = MessageBuilder.createMessage(new Foo1(what), new MessageHeaders(headers));
+		this.template.send(message);
 	}
 
 }

--- a/producer_kafka/src/main/resources/application.yml
+++ b/producer_kafka/src/main/resources/application.yml
@@ -2,4 +2,6 @@ spring:
   kafka:
     producer:
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      # key ser is only required because we are using string keys instead of spring-kafka default int keys
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
 logging.level.org.springframework.cloud.contract: debug

--- a/producer_kafka/src/test/java/com/example/BaseClass.java
+++ b/producer_kafka/src/test/java/com/example/BaseClass.java
@@ -42,4 +42,8 @@ public abstract class BaseClass {
 	public void trigger() {
 		this.controller.sendFoo("example");
 	}
+
+	public void triggerMessage() {
+		this.controller.sendFooAsMessage("example");
+	}
 }

--- a/producer_kafka/src/test/resources/application-test.yml
+++ b/producer_kafka/src/test/resources/application-test.yml
@@ -2,7 +2,6 @@ spring:
   kafka:
     bootstrap-servers: ${spring.embedded.kafka.brokers}
     consumer:
-      properties:
-        "key.serializer": "org.springframework.kafka.support.serializer.JsonSerializer"
-        "key.deserializer": "org.springframework.kafka.support.serializer.JsonDeserializer"
       group-id: groupId
+      # key deser is only required because we are using string keys instead of spring-kafka default int keys
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer

--- a/producer_kafka/src/test/resources/contracts/shouldSendFooAsMessage.groovy
+++ b/producer_kafka/src/test/resources/contracts/shouldSendFooAsMessage.groovy
@@ -1,0 +1,17 @@
+import org.springframework.cloud.contract.spec.Contract
+
+Contract.make {
+	label("triggerMessage")
+	input {
+		triggeredBy("triggerMessage()")
+	}
+	outputMessage {
+		sentTo("topic1")
+		body([
+		        foo: "example"
+		])
+		headers {
+			header('kafka_messageKey', 'key-example')
+		}
+	}
+}


### PR DESCRIPTION
Adds a Kafka message key to the `producer_kafka` and `consumer_kafka` to illustrate the ability to use Kafka message keys in contracts.

Illustrates https://github.com/spring-cloud/spring-cloud-contract/issues/1267