### PR TITLE
Updated producers to use modern Gradle plugin application

### DIFF
--- a/beer_contracts/build.gradle
+++ b/beer_contracts/build.gradle
@@ -28,10 +28,10 @@ repositories {
 }
 
 ext {
-    set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+    set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}]"
 
 dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter'

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 	}
 }
 
-println "Cloud version [${findProperty('BOM_VERSION') ?: verifierVersion}]"
+println "Cloud version [${BOM_VERSION}]"
 
 repositories {
 	mavenCentral()
@@ -27,7 +27,7 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
 dependencies {
-  implementation(platform("org.springframework.cloud:spring-cloud-dependencies:${project.findProperty('BOM_VERSION') ?: BOM_VERSION}"))
+  implementation(platform("org.springframework.cloud:spring-cloud-dependencies:${BOM_VERSION}"))
 }
 
 dependencies {

--- a/consumer/build.gradle
+++ b/consumer/build.gradle
@@ -1,21 +1,9 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/consumer/build.gradle
+++ b/consumer/build.gradle
@@ -18,10 +18,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/consumer/settings.gradle
+++ b/consumer/settings.gradle
@@ -1,1 +1,16 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+	}
+}
+
 rootProject.name = 'beer-api-consumer'

--- a/consumer_camel/build.gradle
+++ b/consumer_camel/build.gradle
@@ -1,21 +1,9 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/consumer_camel/build.gradle
+++ b/consumer_camel/build.gradle
@@ -18,11 +18,11 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 	set('camelVersion', "3.3.0")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}]"
 
 dependencies {
 	implementation("org.apache.camel.springboot:camel-spring-boot-starter:${camelVersion}")

--- a/consumer_camel/settings.gradle
+++ b/consumer_camel/settings.gradle
@@ -1,1 +1,16 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+	}
+}
+
 rootProject.name = 'beer-api-consumer-camel'

--- a/consumer_grpc/build.gradle
+++ b/consumer_grpc/build.gradle
@@ -3,7 +3,7 @@ plugins {
 	id 'org.springframework.boot'
 	id 'io.spring.dependency-management'
 	id 'maven-publish'
-	id "com.google.protobuf" version "0.8.13"
+	id 'com.google.protobuf'
 }
 
 group = 'com.example'

--- a/consumer_grpc/build.gradle
+++ b/consumer_grpc/build.gradle
@@ -19,10 +19,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/consumer_grpc/build.gradle
+++ b/consumer_grpc/build.gradle
@@ -1,25 +1,10 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
-}
-
 plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	id 'maven-publish'
 	id "com.google.protobuf" version "0.8.13"
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/consumer_grpc/settings.gradle
+++ b/consumer_grpc/settings.gradle
@@ -10,6 +10,7 @@ pluginManagement {
 	plugins {
 		id 'org.springframework.boot' version bootVersion
 		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'com.google.protobuf' version '0.8.13'
 	}
 }
 

--- a/consumer_grpc/settings.gradle
+++ b/consumer_grpc/settings.gradle
@@ -1,1 +1,16 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+	}
+}
+
 rootProject.name = 'beer-api-consumer-grpc'

--- a/consumer_java/build.gradle
+++ b/consumer_java/build.gradle
@@ -1,21 +1,9 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/consumer_java/build.gradle
+++ b/consumer_java/build.gradle
@@ -18,10 +18,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/consumer_java/settings.gradle
+++ b/consumer_java/settings.gradle
@@ -1,1 +1,16 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+	}
+}
+
 rootProject.name = 'beer-api-consumer-java'

--- a/consumer_jms_middleware/build.gradle
+++ b/consumer_jms_middleware/build.gradle
@@ -1,21 +1,9 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/consumer_jms_middleware/build.gradle
+++ b/consumer_jms_middleware/build.gradle
@@ -18,10 +18,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/consumer_jms_middleware/settings.gradle
+++ b/consumer_jms_middleware/settings.gradle
@@ -1,1 +1,16 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+	}
+}
+
 rootProject.name = 'beer-api-consumer-jms-middleware'

--- a/consumer_kafka/build.gradle
+++ b/consumer_kafka/build.gradle
@@ -1,21 +1,9 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/consumer_kafka/build.gradle
+++ b/consumer_kafka/build.gradle
@@ -18,10 +18,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/consumer_kafka/settings.gradle
+++ b/consumer_kafka/settings.gradle
@@ -1,1 +1,16 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+	}
+}
+
 rootProject.name = 'beer-api-consumer-kafka'

--- a/consumer_kafka_middleware/build.gradle
+++ b/consumer_kafka_middleware/build.gradle
@@ -1,21 +1,9 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/consumer_kafka_middleware/build.gradle
+++ b/consumer_kafka_middleware/build.gradle
@@ -18,10 +18,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/consumer_kafka_middleware/settings.gradle
+++ b/consumer_kafka_middleware/settings.gradle
@@ -1,1 +1,16 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+	}
+}
+
 rootProject.name = 'beer-api-consumer-kafka-middleware'

--- a/consumer_kotlin/build.gradle
+++ b/consumer_kotlin/build.gradle
@@ -1,21 +1,9 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/consumer_kotlin/build.gradle
+++ b/consumer_kotlin/build.gradle
@@ -18,10 +18,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/consumer_kotlin/settings.gradle
+++ b/consumer_kotlin/settings.gradle
@@ -1,1 +1,16 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+	}
+}
+
 rootProject.name = 'beer-api-consumer-kotlin'

--- a/consumer_kotlin_ftw/settings.gradle.kts
+++ b/consumer_kotlin_ftw/settings.gradle.kts
@@ -7,13 +7,9 @@ pluginManagement {
         maven { url = uri("https://repo.spring.io/snapshot") }
         gradlePluginPortal()
     }
-    resolutionStrategy {
+    plugins {
         val bootVersion: String by settings
-        eachPlugin {
-            if (requested.id.id == "org.springframework.boot") {
-                useModule("org.springframework.boot:spring-boot-gradle-plugin:$bootVersion")
-            }
-        }
+        id("org.springframework.boot") version bootVersion
     }
 }
 rootProject.name = "consumer-kotlin-ftw-gradle"

--- a/consumer_pact/build.gradle
+++ b/consumer_pact/build.gradle
@@ -1,23 +1,10 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		classpath "au.com.dius.pact.provider:gradle:4.1.4"
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	id 'maven-publish'
+	id 'au.com.dius.pact' version '4.1.4'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-apply plugin: 'maven-publish'
-apply plugin: 'au.com.dius.pact'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/consumer_pact/build.gradle
+++ b/consumer_pact/build.gradle
@@ -3,7 +3,7 @@ plugins {
 	id 'org.springframework.boot'
 	id 'io.spring.dependency-management'
 	id 'maven-publish'
-	id 'au.com.dius.pact' version '4.1.4'
+	id 'au.com.dius.pact'
 }
 
 group = 'com.example'

--- a/consumer_pact/build.gradle
+++ b/consumer_pact/build.gradle
@@ -19,10 +19,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/consumer_pact/settings.gradle
+++ b/consumer_pact/settings.gradle
@@ -10,6 +10,7 @@ pluginManagement {
 	plugins {
 		id 'org.springframework.boot' version bootVersion
 		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'au.com.dius.pact' version '4.1.4'
 	}
 }
 

--- a/consumer_pact/settings.gradle
+++ b/consumer_pact/settings.gradle
@@ -1,1 +1,16 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+	}
+}
+
 rootProject.name = 'beer-api-consumer-pact'

--- a/consumer_pact_stubrunner/build.gradle
+++ b/consumer_pact_stubrunner/build.gradle
@@ -1,21 +1,9 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/consumer_pact_stubrunner/build.gradle
+++ b/consumer_pact_stubrunner/build.gradle
@@ -18,10 +18,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/consumer_pact_stubrunner/settings.gradle
+++ b/consumer_pact_stubrunner/settings.gradle
@@ -1,1 +1,16 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+	}
+}
+
 rootProject.name = 'beer-api-consumer-pact-stubrunner'

--- a/consumer_proto/build.gradle
+++ b/consumer_proto/build.gradle
@@ -1,21 +1,9 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/consumer_proto/build.gradle
+++ b/consumer_proto/build.gradle
@@ -18,10 +18,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/consumer_proto/settings.gradle
+++ b/consumer_proto/settings.gradle
@@ -1,1 +1,16 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+	}
+}
+
 rootProject.name = 'beer-api-consumer-proto'

--- a/consumer_rabbit_middleware/build.gradle
+++ b/consumer_rabbit_middleware/build.gradle
@@ -1,21 +1,9 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/consumer_rabbit_middleware/build.gradle
+++ b/consumer_rabbit_middleware/build.gradle
@@ -18,10 +18,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/consumer_rabbit_middleware/settings.gradle
+++ b/consumer_rabbit_middleware/settings.gradle
@@ -1,1 +1,16 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+	}
+}
+
 rootProject.name = 'beer-api-consumer-rabbit-middleware'

--- a/consumer_security/build.gradle
+++ b/consumer_security/build.gradle
@@ -1,21 +1,9 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/consumer_security/build.gradle
+++ b/consumer_security/build.gradle
@@ -18,10 +18,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/consumer_security/settings.gradle
+++ b/consumer_security/settings.gradle
@@ -1,1 +1,16 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+	}
+}
+
 rootProject.name = 'beer-api-consumer-security'

--- a/consumer_with_discovery/build.gradle
+++ b/consumer_with_discovery/build.gradle
@@ -1,21 +1,9 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/consumer_with_discovery/build.gradle
+++ b/consumer_with_discovery/build.gradle
@@ -18,10 +18,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/consumer_with_discovery/settings.gradle
+++ b/consumer_with_discovery/settings.gradle
@@ -1,1 +1,16 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+	}
+}
+
 rootProject.name = 'beer-api-consumer-discovery'

--- a/consumer_with_junit4/build.gradle
+++ b/consumer_with_junit4/build.gradle
@@ -1,21 +1,9 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/consumer_with_junit4/build.gradle
+++ b/consumer_with_junit4/build.gradle
@@ -18,10 +18,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/consumer_with_junit4/settings.gradle
+++ b/consumer_with_junit4/settings.gradle
@@ -1,1 +1,16 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+	}
+}
+
 rootProject.name = 'beer-api-consumer-junit4'

--- a/consumer_with_latest_2_2_features/build.gradle
+++ b/consumer_with_latest_2_2_features/build.gradle
@@ -1,21 +1,9 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/consumer_with_latest_2_2_features/build.gradle
+++ b/consumer_with_latest_2_2_features/build.gradle
@@ -18,10 +18,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/consumer_with_latest_2_2_features/settings.gradle
+++ b/consumer_with_latest_2_2_features/settings.gradle
@@ -1,1 +1,16 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+	}
+}
+
 rootProject.name = 'beer-api-consumer-with-latest-22'

--- a/consumer_with_latest_3_0_features_gradle/build.gradle
+++ b/consumer_with_latest_3_0_features_gradle/build.gradle
@@ -1,21 +1,9 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/consumer_with_latest_3_0_features_gradle/build.gradle
+++ b/consumer_with_latest_3_0_features_gradle/build.gradle
@@ -18,10 +18,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/consumer_with_latest_3_0_features_gradle/settings.gradle
+++ b/consumer_with_latest_3_0_features_gradle/settings.gradle
@@ -1,1 +1,16 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+	}
+}
+
 rootProject.name = 'beer-api-consumer-with-latest-30'

--- a/consumer_with_restdocs/build.gradle
+++ b/consumer_with_restdocs/build.gradle
@@ -1,21 +1,9 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/consumer_with_restdocs/build.gradle
+++ b/consumer_with_restdocs/build.gradle
@@ -18,10 +18,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/consumer_with_restdocs/settings.gradle
+++ b/consumer_with_restdocs/settings.gradle
@@ -1,1 +1,16 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+	}
+}
+
 rootProject.name = 'beer-api-consumer-restdocs'

--- a/consumer_with_secured_webflux/build.gradle
+++ b/consumer_with_secured_webflux/build.gradle
@@ -19,10 +19,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-webflux")

--- a/consumer_with_secured_webflux/build.gradle
+++ b/consumer_with_secured_webflux/build.gradle
@@ -1,27 +1,10 @@
-buildscript {
-	ext {
-		kotlinVersion = '1.4.10'
-	}
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}")
-		classpath("org.jetbrains.kotlin:kotlin-allopen:${kotlinVersion}")
-	}
+plugins {
+	id 'org.jetbrains.kotlin.jvm'
+	id 'org.jetbrains.kotlin.plugin.spring'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	id 'maven-publish'
 }
-
-apply plugin: 'kotlin'
-apply plugin: 'kotlin-spring'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/consumer_with_secured_webflux/gradle.properties
+++ b/consumer_with_secured_webflux/gradle.properties
@@ -3,3 +3,4 @@ verifierVersion=3.0.3-SNAPSHOT
 bootVersion=2.4.5-SNAPSHOT
 BOM_VERSION=2020.0.3-SNAPSHOT
 springWebTestClientVersion=3.3.0
+kotlinVersion=1.4.10

--- a/consumer_with_secured_webflux/settings.gradle
+++ b/consumer_with_secured_webflux/settings.gradle
@@ -1,1 +1,18 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.jetbrains.kotlin.jvm' version kotlinVersion
+		id 'org.jetbrains.kotlin.plugin.spring' version kotlinVersion
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+	}
+}
+
 rootProject.name = 'secured-producer-webflux'

--- a/consumer_with_stubs_per_consumer/build.gradle
+++ b/consumer_with_stubs_per_consumer/build.gradle
@@ -1,21 +1,9 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/consumer_with_stubs_per_consumer/build.gradle
+++ b/consumer_with_stubs_per_consumer/build.gradle
@@ -18,10 +18,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/consumer_with_stubs_per_consumer/settings.gradle
+++ b/consumer_with_stubs_per_consumer/settings.gradle
@@ -1,1 +1,16 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+	}
+}
+
 rootProject.name = 'beer-api-consumer-with-stub-per-consumer'

--- a/producer/build.gradle
+++ b/producer/build.gradle
@@ -21,10 +21,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}], Contract version [${findProperty('verifierVersion') ?: verifierVersion}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}], Contract version [${verifierVersion}]"
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'

--- a/producer/build.gradle
+++ b/producer/build.gradle
@@ -1,28 +1,12 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		//remove::start[]
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${findProperty('verifierVersion') ?: verifierVersion}"
-		classpath "com.example:beer-common:0.0.1-SNAPSHOT"
-		// remove::end[]
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	//remove::start[]
+	id 'org.springframework.cloud.contract'
+	//remove::end[]
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-//remove::start[]
-apply plugin: 'spring-cloud-contract'
-// remove::end[]
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/producer/settings.gradle
+++ b/producer/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'org.springframework.cloud.contract' version verifierVersion
+	}
+}
+
 rootProject.name = 'beer-api-producer'

--- a/producer_advanced/build.gradle
+++ b/producer_advanced/build.gradle
@@ -21,10 +21,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}], Contract version [${findProperty('verifierVersion') ?: verifierVersion}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}], Contract version [${verifierVersion}]"
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'

--- a/producer_advanced/build.gradle
+++ b/producer_advanced/build.gradle
@@ -1,27 +1,12 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		//remove::start[]
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${findProperty('verifierVersion') ?: verifierVersion}"
-		// remove::end[]
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	//remove::start[]
+	id 'org.springframework.cloud.contract'
+	//remove::end[]
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-//remove::start[]
-apply plugin: 'spring-cloud-contract'
-// remove::end[]
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/producer_advanced/settings.gradle
+++ b/producer_advanced/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'org.springframework.cloud.contract' version verifierVersion
+	}
+}
+
 rootProject.name = 'beer-api-producer-advanced'

--- a/producer_camel/build.gradle
+++ b/producer_camel/build.gradle
@@ -1,27 +1,12 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		//remove::start[]
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${findProperty('verifierVersion') ?: verifierVersion}"
-		// remove::end[]
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	//remove::start[]
+	id 'org.springframework.cloud.contract'
+	//remove::end[]
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-//remove::start[]
-apply plugin: 'spring-cloud-contract'
-// remove::end[]
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/producer_camel/build.gradle
+++ b/producer_camel/build.gradle
@@ -21,11 +21,11 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 	set('camelVersion', "3.3.0")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}], Contract version [${findProperty('verifierVersion') ?: verifierVersion}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}], Contract version [${verifierVersion}]"
 
 dependencies {
 	implementation("org.apache.camel.springboot:camel-spring-boot-starter:${camelVersion}")

--- a/producer_camel/settings.gradle
+++ b/producer_camel/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'org.springframework.cloud.contract' version verifierVersion
+	}
+}
+
 rootProject.name = 'beer-api-producer-camel'

--- a/producer_graphql/build.gradle
+++ b/producer_graphql/build.gradle
@@ -1,27 +1,12 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		//remove::start[]
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${findProperty('verifierVersion') ?: verifierVersion}"
-		// remove::end[]
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	//remove::start[]
+	id 'org.springframework.cloud.contract'
+	//remove::end[]
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-//remove::start[]
-apply plugin: 'spring-cloud-contract'
-// remove::end[]
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/producer_graphql/build.gradle
+++ b/producer_graphql/build.gradle
@@ -20,10 +20,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}], Contract version [${findProperty('verifierVersion') ?: verifierVersion}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}], Contract version [${verifierVersion}]"
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/producer_graphql/settings.gradle
+++ b/producer_graphql/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'org.springframework.cloud.contract' version verifierVersion
+	}
+}
+
 rootProject.name = 'beer-api-producer-graphql'

--- a/producer_grpc/build.gradle
+++ b/producer_grpc/build.gradle
@@ -1,31 +1,13 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		//remove::start[]
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${findProperty('verifierVersion') ?: verifierVersion}"
-		// remove::end[]
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
-}
-
 plugins {
-	id "com.google.protobuf" version "0.8.13"
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	//remove::start[]
+	id 'org.springframework.cloud.contract'
+	//remove::end[]
+	id 'maven-publish'
+	id 'com.google.protobuf' version '0.8.13'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-//remove::start[]
-apply plugin: 'spring-cloud-contract'
-// remove::end[]
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/producer_grpc/build.gradle
+++ b/producer_grpc/build.gradle
@@ -33,10 +33,10 @@ sourceSets {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}], Contract version [${findProperty('verifierVersion') ?: verifierVersion}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}], Contract version [${verifierVersion}]"
 
 dependencies {
 	implementation 'net.devh:grpc-server-spring-boot-starter:2.10.1.RELEASE'

--- a/producer_grpc/build.gradle
+++ b/producer_grpc/build.gradle
@@ -6,7 +6,7 @@ plugins {
 	id 'org.springframework.cloud.contract'
 	//remove::end[]
 	id 'maven-publish'
-	id 'com.google.protobuf' version '0.8.13'
+	id 'com.google.protobuf'
 }
 
 group = 'com.example'

--- a/producer_grpc/settings.gradle
+++ b/producer_grpc/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'org.springframework.cloud.contract' version verifierVersion
+	}
+}
+
 rootProject.name = 'beer-api-producer-grpc'

--- a/producer_grpc/settings.gradle
+++ b/producer_grpc/settings.gradle
@@ -11,6 +11,7 @@ pluginManagement {
 		id 'org.springframework.boot' version bootVersion
 		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
 		id 'org.springframework.cloud.contract' version verifierVersion
+		id 'com.google.protobuf' version '0.8.13'
 	}
 }
 

--- a/producer_java/build.gradle
+++ b/producer_java/build.gradle
@@ -21,10 +21,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}], Contract version [${findProperty('verifierVersion') ?: verifierVersion}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}], Contract version [${verifierVersion}]"
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'

--- a/producer_java/build.gradle
+++ b/producer_java/build.gradle
@@ -1,28 +1,12 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		//remove::start[]
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${findProperty('verifierVersion') ?: verifierVersion}"
-		classpath "com.example:beer-common:0.0.1-SNAPSHOT"
-		// remove::end[]
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	//remove::start[]
+	id 'org.springframework.cloud.contract'
+	//remove::end[]
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-//remove::start[]
-apply plugin: 'spring-cloud-contract'
-// remove::end[]
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/producer_java/settings.gradle
+++ b/producer_java/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'org.springframework.cloud.contract' version verifierVersion
+	}
+}
+
 rootProject.name = 'beer-api-producer-java'

--- a/producer_jaxrs/build.gradle
+++ b/producer_jaxrs/build.gradle
@@ -1,27 +1,12 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		//remove::start[]
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${findProperty('verifierVersion') ?: verifierVersion}"
-		// remove::end[]
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	//remove::start[]
+	id 'org.springframework.cloud.contract'
+	//remove::end[]
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-//remove::start[]
-apply plugin: 'spring-cloud-contract'
-// remove::end[]
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/producer_jaxrs/build.gradle
+++ b/producer_jaxrs/build.gradle
@@ -21,10 +21,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}], Contract version [${findProperty('verifierVersion') ?: verifierVersion}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}], Contract version [${verifierVersion}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-jersey")

--- a/producer_jaxrs/settings.gradle
+++ b/producer_jaxrs/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'org.springframework.cloud.contract' version verifierVersion
+	}
+}
+
 rootProject.name = 'beer-api-producer-jaxrs'

--- a/producer_jaxrs_spring/build.gradle
+++ b/producer_jaxrs_spring/build.gradle
@@ -1,18 +1,11 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		// remove::start[]
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${findProperty('verifierVersion') ?: verifierVersion}"
-		// remove::end[]
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	//remove::start[]
+	id 'org.springframework.cloud.contract'
+	//remove::end[]
+	id 'maven-publish'
 }
 
 println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}], Contract version [${findProperty('verifierVersion') ?: verifierVersion}]"
@@ -27,14 +20,6 @@ repositories {
 	maven { url "https://repo.spring.io/milestone" }
 	maven { url "https://repo.spring.io/release" }
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: "io.spring.dependency-management"
-// remove::start[]
-apply plugin: 'spring-cloud-contract'
-// remove::end[]
-apply plugin: 'maven-publish'
 
 dependencies {
   implementation(platform("org.springframework.cloud:spring-cloud-dependencies:${project.findProperty('BOM_VERSION') ?: BOM_VERSION}"))

--- a/producer_jaxrs_spring/build.gradle
+++ b/producer_jaxrs_spring/build.gradle
@@ -8,7 +8,7 @@ plugins {
 	id 'maven-publish'
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}], Contract version [${findProperty('verifierVersion') ?: verifierVersion}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}], Contract version [${verifierVersion}]"
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-  implementation(platform("org.springframework.cloud:spring-cloud-dependencies:${project.findProperty('BOM_VERSION') ?: BOM_VERSION}"))
+  implementation(platform("org.springframework.cloud:spring-cloud-dependencies:${BOM_VERSION}"))
 }
 
 

--- a/producer_jaxrs_spring/settings.gradle
+++ b/producer_jaxrs_spring/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'org.springframework.cloud.contract' version verifierVersion
+	}
+}
+
 rootProject.name = 'beer-api-producer-jaxrs-spring'

--- a/producer_jms_middleware/build.gradle
+++ b/producer_jms_middleware/build.gradle
@@ -1,27 +1,12 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		//remove::start[]
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${findProperty('verifierVersion') ?: verifierVersion}"
-		// remove::end[]
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	//remove::start[]
+	id 'org.springframework.cloud.contract'
+	//remove::end[]
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-//remove::start[]
-apply plugin: 'spring-cloud-contract'
-// remove::end[]
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/producer_jms_middleware/build.gradle
+++ b/producer_jms_middleware/build.gradle
@@ -21,10 +21,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}], Contract version [${findProperty('verifierVersion') ?: verifierVersion}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}], Contract version [${verifierVersion}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/producer_jms_middleware/settings.gradle
+++ b/producer_jms_middleware/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'org.springframework.cloud.contract' version verifierVersion
+	}
+}
+
 rootProject.name = 'beer-api-producer-jms-middleware'

--- a/producer_kafka/build.gradle
+++ b/producer_kafka/build.gradle
@@ -1,27 +1,12 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		//remove::start[]
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${findProperty('verifierVersion') ?: verifierVersion}"
-		// remove::end[]
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	//remove::start[]
+	id 'org.springframework.cloud.contract'
+	//remove::end[]
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-//remove::start[]
-apply plugin: 'spring-cloud-contract'
-// remove::end[]
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/producer_kafka/build.gradle
+++ b/producer_kafka/build.gradle
@@ -21,10 +21,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}], Contract version [${findProperty('verifierVersion') ?: verifierVersion}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}], Contract version [${verifierVersion}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/producer_kafka/settings.gradle
+++ b/producer_kafka/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'org.springframework.cloud.contract' version verifierVersion
+	}
+}
+
 rootProject.name = 'beer-api-producer-kafka'

--- a/producer_kafka_middleware/build.gradle
+++ b/producer_kafka_middleware/build.gradle
@@ -1,27 +1,12 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		//remove::start[]
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${findProperty('verifierVersion') ?: verifierVersion}"
-		// remove::end[]
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	//remove::start[]
+	id 'org.springframework.cloud.contract'
+	//remove::end[]
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-//remove::start[]
-apply plugin: 'spring-cloud-contract'
-// remove::end[]
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/producer_kafka_middleware/build.gradle
+++ b/producer_kafka_middleware/build.gradle
@@ -21,10 +21,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}], Contract version [${findProperty('verifierVersion') ?: verifierVersion}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}], Contract version [${verifierVersion}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/producer_kafka_middleware/settings.gradle
+++ b/producer_kafka_middleware/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'org.springframework.cloud.contract' version verifierVersion
+	}
+}
+
 rootProject.name = 'beer-api-producer-kafka-middleware'

--- a/producer_kotlin/build.gradle
+++ b/producer_kotlin/build.gradle
@@ -1,33 +1,13 @@
-buildscript {
-	ext {
-		kotlinVersion = '1.4.10'
-	}
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		//remove::start[]
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${findProperty('verifierVersion') ?: verifierVersion}"
-		// remove::end[]
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-		classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}")
-		classpath("org.jetbrains.kotlin:kotlin-allopen:${kotlinVersion}")
-	}
+plugins {
+	id 'org.jetbrains.kotlin.jvm'
+	id 'org.jetbrains.kotlin.plugin.spring'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	//remove::start[]
+	id 'org.springframework.cloud.contract'
+	//remove::end[]
+	id 'maven-publish'
 }
-
-apply plugin: 'kotlin'
-apply plugin: 'kotlin-spring'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-//remove::start[]
-apply plugin: 'spring-cloud-contract'
-// remove::end[]
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/producer_kotlin/build.gradle
+++ b/producer_kotlin/build.gradle
@@ -22,10 +22,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}], Contract version [${findProperty('verifierVersion') ?: verifierVersion}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}], Contract version [${verifierVersion}]"
 
 dependencies {
 	implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion" // Required for Kotlin integration

--- a/producer_kotlin/gradle.properties
+++ b/producer_kotlin/gradle.properties
@@ -2,3 +2,4 @@ org.gradle.daemon=false
 verifierVersion=3.0.3-SNAPSHOT
 bootVersion=2.4.5-SNAPSHOT
 BOM_VERSION=2020.0.3-SNAPSHOT
+kotlinVersion=1.4.10

--- a/producer_kotlin/settings.gradle
+++ b/producer_kotlin/settings.gradle
@@ -1,1 +1,19 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url = uri("https://repo.spring.io/release") }
+		maven { url = uri("https://repo.spring.io/milestone") }
+		maven { url = uri("https://repo.spring.io/snapshot") }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'org.springframework.cloud.contract' version verifierVersion
+		id 'org.jetbrains.kotlin.jvm' version kotlinVersion
+		id 'org.jetbrains.kotlin.plugin.spring' version kotlinVersion
+	}
+}
+
 rootProject.name = 'beer-api-producer-kotlin'

--- a/producer_kotlin_ftw/build.gradle.kts
+++ b/producer_kotlin_ftw/build.gradle.kts
@@ -1,20 +1,6 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-buildscript {
-	val verifierVersion: String by extra
-    repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url = uri("https://repo.spring.io/release") }
-		maven { url = uri("https://repo.spring.io/milestone") }
-		maven { url = uri("https://repo.spring.io/snapshot") }
-    }
-        
-    dependencies {
-    }
-}
-
 plugins {
 	id("org.springframework.boot")
 	id("io.spring.dependency-management") version "1.0.10.RELEASE"

--- a/producer_pact/build.gradle
+++ b/producer_pact/build.gradle
@@ -1,27 +1,12 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		//remove::start[]
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${findProperty('verifierVersion') ?: verifierVersion}"
-		// remove::end[]
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	//remove::start[]
+	id 'org.springframework.cloud.contract'
+	//remove::end[]
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-//remove::start[]
-apply plugin: 'spring-cloud-contract'
-// remove::end[]
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/producer_pact/build.gradle
+++ b/producer_pact/build.gradle
@@ -21,10 +21,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}], Contract version [${findProperty('verifierVersion') ?: verifierVersion}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}], Contract version [${verifierVersion}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/producer_pact/settings.gradle
+++ b/producer_pact/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'org.springframework.cloud.contract' version verifierVersion
+	}
+}
+
 rootProject.name = 'beer-api-producer-pact'

--- a/producer_proto/build.gradle
+++ b/producer_proto/build.gradle
@@ -1,27 +1,12 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		//remove::start[]
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${findProperty('verifierVersion') ?: verifierVersion}"
-		// remove::end[]
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	//remove::start[]
+	id 'org.springframework.cloud.contract'
+	//remove::end[]
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-//remove::start[]
-apply plugin: 'spring-cloud-contract'
-// remove::end[]
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/producer_proto/build.gradle
+++ b/producer_proto/build.gradle
@@ -21,10 +21,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}], Contract version [${findProperty('verifierVersion') ?: verifierVersion}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}], Contract version [${verifierVersion}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/producer_proto/settings.gradle
+++ b/producer_proto/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'org.springframework.cloud.contract' version verifierVersion
+	}
+}
+
 rootProject.name = 'beer-api-producer-proto'

--- a/producer_rabbit_middleware/build.gradle
+++ b/producer_rabbit_middleware/build.gradle
@@ -1,27 +1,12 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		//remove::start[]
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${findProperty('verifierVersion') ?: verifierVersion}"
-		// remove::end[]
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	//remove::start[]
+	id 'org.springframework.cloud.contract'
+	//remove::end[]
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-//remove::start[]
-apply plugin: 'spring-cloud-contract'
-// remove::end[]
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/producer_rabbit_middleware/build.gradle
+++ b/producer_rabbit_middleware/build.gradle
@@ -21,10 +21,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}], Contract version [${findProperty('verifierVersion') ?: verifierVersion}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}], Contract version [${verifierVersion}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/producer_rabbit_middleware/settings.gradle
+++ b/producer_rabbit_middleware/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'org.springframework.cloud.contract' version verifierVersion
+	}
+}
+
 rootProject.name = 'beer-api-producer-rabbit-middleware'

--- a/producer_router_function/build.gradle
+++ b/producer_router_function/build.gradle
@@ -21,13 +21,13 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 	// example of using 4.x version of rest assured
 	set('rest-assured.version', '4.0.0')
 	set('restAssuredVersion', '4.0.0')
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}], Contract version [${findProperty('verifierVersion') ?: verifierVersion}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}], Contract version [${verifierVersion}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-webflux")

--- a/producer_router_function/build.gradle
+++ b/producer_router_function/build.gradle
@@ -1,28 +1,12 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		//remove::start[]
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${findProperty('verifierVersion') ?: verifierVersion}"
-		classpath "com.example:beer-common:0.0.1-SNAPSHOT"
-		// remove::end[]
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	//remove::start[]
+	id 'org.springframework.cloud.contract'
+	//remove::end[]
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-//remove::start[]
-apply plugin: 'spring-cloud-contract'
-// remove::end[]
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/producer_router_function/settings.gradle
+++ b/producer_router_function/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'org.springframework.cloud.contract' version verifierVersion
+	}
+}
+
 rootProject.name = 'beer-api-producer-routerfunction-webtestclient'

--- a/producer_security/build.gradle
+++ b/producer_security/build.gradle
@@ -1,27 +1,12 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		//remove::start[]
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${findProperty('verifierVersion') ?: verifierVersion}"
-		// remove::end[]
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	//remove::start[]
+	id 'org.springframework.cloud.contract'
+	//remove::end[]
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-//remove::start[]
-apply plugin: 'spring-cloud-contract'
-// remove::end[]
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/producer_security/build.gradle
+++ b/producer_security/build.gradle
@@ -21,10 +21,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}], Contract version [${findProperty('verifierVersion') ?: verifierVersion}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}], Contract version [${verifierVersion}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/producer_security/settings.gradle
+++ b/producer_security/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'org.springframework.cloud.contract' version verifierVersion
+	}
+}
+
 rootProject.name = 'beer-api-producer-security'

--- a/producer_testng/build.gradle
+++ b/producer_testng/build.gradle
@@ -1,27 +1,12 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		//remove::start[]
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${findProperty('verifierVersion') ?: verifierVersion}"
-		// remove::end[]
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	//remove::start[]
+	id 'org.springframework.cloud.contract'
+	//remove::end[]
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-//remove::start[]
-apply plugin: 'spring-cloud-contract'
-// remove::end[]
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/producer_testng/build.gradle
+++ b/producer_testng/build.gradle
@@ -21,10 +21,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}], Contract version [${findProperty('verifierVersion') ?: verifierVersion}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}], Contract version [${verifierVersion}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/producer_testng/settings.gradle
+++ b/producer_testng/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'org.springframework.cloud.contract' version verifierVersion
+	}
+}
+
 rootProject.name = 'beer-api-producer-testng'

--- a/producer_webflux/build.gradle
+++ b/producer_webflux/build.gradle
@@ -21,10 +21,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}], Contract version [${findProperty('verifierVersion') ?: verifierVersion}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}], Contract version [${verifierVersion}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-webflux")

--- a/producer_webflux/build.gradle
+++ b/producer_webflux/build.gradle
@@ -1,28 +1,12 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		//remove::start[]
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${findProperty('verifierVersion') ?: verifierVersion}"
-		classpath "com.example:beer-common:0.0.1-SNAPSHOT"
-		// remove::end[]
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	//remove::start[]
+	id 'org.springframework.cloud.contract'
+	//remove::end[]
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-//remove::start[]
-apply plugin: 'spring-cloud-contract'
-// remove::end[]
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/producer_webflux/settings.gradle
+++ b/producer_webflux/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'org.springframework.cloud.contract' version verifierVersion
+	}
+}
+
 rootProject.name = 'beer-api-producer-webflux'

--- a/producer_webflux_security/build.gradle
+++ b/producer_webflux_security/build.gradle
@@ -1,33 +1,13 @@
-buildscript {
-	ext {
-		kotlinVersion = '1.4.10'
-	}
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		//remove::start[]
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${findProperty('verifierVersion') ?: verifierVersion}"
-		// remove::end[]
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-		classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}")
-		classpath("org.jetbrains.kotlin:kotlin-allopen:${kotlinVersion}")
-	}
+plugins {
+	id 'org.jetbrains.kotlin.jvm'
+	id 'org.jetbrains.kotlin.plugin.spring'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	//remove::start[]
+	id 'org.springframework.cloud.contract'
+	//remove::end[]
+	id 'maven-publish'
 }
-
-apply plugin: 'kotlin'
-apply plugin: 'kotlin-spring'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-//remove::start[]
-apply plugin: 'spring-cloud-contract'
-// remove::end[]
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/producer_webflux_security/build.gradle
+++ b/producer_webflux_security/build.gradle
@@ -22,10 +22,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}], Contract version [${findProperty('verifierVersion') ?: verifierVersion}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}], Contract version [${verifierVersion}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-webflux")

--- a/producer_webflux_security/gradle.properties
+++ b/producer_webflux_security/gradle.properties
@@ -3,3 +3,4 @@ verifierVersion=3.0.3-SNAPSHOT
 bootVersion=2.4.5-SNAPSHOT
 BOM_VERSION=2020.0.3-SNAPSHOT
 springWebTestClientVersion=3.3.0
+kotlinVersion=1.4.10

--- a/producer_webflux_security/settings.gradle
+++ b/producer_webflux_security/settings.gradle
@@ -1,1 +1,19 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'org.springframework.cloud.contract' version verifierVersion
+		id 'org.jetbrains.kotlin.jvm' version kotlinVersion
+		id 'org.jetbrains.kotlin.plugin.spring' version kotlinVersion
+	}
+}
+
 rootProject.name = 'secured-producer-webflux'

--- a/producer_webflux_webtestclient/build.gradle
+++ b/producer_webflux_webtestclient/build.gradle
@@ -21,12 +21,12 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 	set('rest-assured.version', "4.0.0")
 	set('restAssuredVersion', "4.0.0")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}], Contract version [${findProperty('verifierVersion') ?: verifierVersion}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}], Contract version [${verifierVersion}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-webflux")

--- a/producer_webflux_webtestclient/build.gradle
+++ b/producer_webflux_webtestclient/build.gradle
@@ -1,28 +1,12 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		//remove::start[]
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${findProperty('verifierVersion') ?: verifierVersion}"
-		classpath "com.example:beer-common:0.0.1-SNAPSHOT"
-		// remove::end[]
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	//remove::start[]
+	id 'org.springframework.cloud.contract'
+	//remove::end[]
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-//remove::start[]
-apply plugin: 'spring-cloud-contract'
-// remove::end[]
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/producer_webflux_webtestclient/settings.gradle
+++ b/producer_webflux_webtestclient/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'org.springframework.cloud.contract' version verifierVersion
+	}
+}
+
 rootProject.name = 'beer-api-producer-webflux-webtestclient'

--- a/producer_with_dsl_restdocs/build.gradle
+++ b/producer_with_dsl_restdocs/build.gradle
@@ -1,27 +1,12 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		//remove::start[]
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${findProperty('verifierVersion') ?: verifierVersion}"
-		// remove::end[]
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	//remove::start[]
+	id 'org.springframework.cloud.contract'
+	//remove::end[]
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-//remove::start[]
-apply plugin: 'spring-cloud-contract'
-// remove::end[]
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/producer_with_dsl_restdocs/build.gradle
+++ b/producer_with_dsl_restdocs/build.gradle
@@ -21,10 +21,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}], Contract version [${findProperty('verifierVersion') ?: verifierVersion}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}], Contract version [${verifierVersion}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/producer_with_dsl_restdocs/settings.gradle
+++ b/producer_with_dsl_restdocs/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'org.springframework.cloud.contract' version verifierVersion
+	}
+}
+
 rootProject.name = 'beer-api-producer-with-dsl-restdocs'

--- a/producer_with_empty_git/build.gradle
+++ b/producer_with_empty_git/build.gradle
@@ -1,27 +1,12 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		//remove::start[]
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${findProperty('verifierVersion') ?: verifierVersion}"
-		// remove::end[]
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	//remove::start[]
+	id 'org.springframework.cloud.contract'
+	//remove::end[]
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-//remove::start[]
-apply plugin: 'spring-cloud-contract'
-// remove::end[]
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/producer_with_empty_git/build.gradle
+++ b/producer_with_empty_git/build.gradle
@@ -21,10 +21,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}], Contract version [${findProperty('verifierVersion') ?: verifierVersion}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}], Contract version [${verifierVersion}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/producer_with_empty_git/settings.gradle
+++ b/producer_with_empty_git/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'org.springframework.cloud.contract' version verifierVersion
+	}
+}
+
 rootProject.name = 'beer-api-producer-empty-git'

--- a/producer_with_external_contracts/build.gradle
+++ b/producer_with_external_contracts/build.gradle
@@ -1,27 +1,12 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		//remove::start[]
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${findProperty('verifierVersion') ?: verifierVersion}"
-		// remove::end[]
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	//remove::start[]
+	id 'org.springframework.cloud.contract'
+	//remove::end[]
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-//remove::start[]
-apply plugin: 'spring-cloud-contract'
-// remove::end[]
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/producer_with_external_contracts/build.gradle
+++ b/producer_with_external_contracts/build.gradle
@@ -21,10 +21,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}], Contract version [${findProperty('verifierVersion') ?: verifierVersion}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}], Contract version [${verifierVersion}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/producer_with_external_contracts/settings.gradle
+++ b/producer_with_external_contracts/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'org.springframework.cloud.contract' version verifierVersion
+	}
+}
+
 rootProject.name = 'beer-api-producer-external'

--- a/producer_with_git/build.gradle
+++ b/producer_with_git/build.gradle
@@ -1,27 +1,12 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		//remove::start[]
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${findProperty('verifierVersion') ?: verifierVersion}"
-		// remove::end[]
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	//remove::start[]
+	id 'org.springframework.cloud.contract'
+	//remove::end[]
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-//remove::start[]
-apply plugin: 'spring-cloud-contract'
-// remove::end[]
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/producer_with_git/build.gradle
+++ b/producer_with_git/build.gradle
@@ -21,10 +21,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}], Contract version [${findProperty('verifierVersion') ?: verifierVersion}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}], Contract version [${verifierVersion}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/producer_with_git/settings.gradle
+++ b/producer_with_git/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'org.springframework.cloud.contract' version verifierVersion
+	}
+}
+
 rootProject.name = 'beer-api-producer-git'

--- a/producer_with_junit4/build.gradle
+++ b/producer_with_junit4/build.gradle
@@ -21,10 +21,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}], Contract version [${findProperty('verifierVersion') ?: verifierVersion}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}], Contract version [${verifierVersion}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/producer_with_junit4/build.gradle
+++ b/producer_with_junit4/build.gradle
@@ -1,28 +1,12 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		//remove::start[]
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${findProperty('verifierVersion') ?: verifierVersion}"
-		classpath "com.example:beer-common:0.0.1-SNAPSHOT"
-		// remove::end[]
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	//remove::start[]
+	id 'org.springframework.cloud.contract'
+	//remove::end[]
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-//remove::start[]
-apply plugin: 'spring-cloud-contract'
-// remove::end[]
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/producer_with_junit4/settings.gradle
+++ b/producer_with_junit4/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'org.springframework.cloud.contract' version verifierVersion
+	}
+}
+
 rootProject.name = 'beer-api-producer-junit4'

--- a/producer_with_latest_2_2_features/build.gradle
+++ b/producer_with_latest_2_2_features/build.gradle
@@ -1,27 +1,12 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		//remove::start[]
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${findProperty('verifierVersion') ?: verifierVersion}"
-		// remove::end[]
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	//remove::start[]
+	id 'org.springframework.cloud.contract'
+	//remove::end[]
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-//remove::start[]
-apply plugin: 'spring-cloud-contract'
-// remove::end[]
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/producer_with_latest_2_2_features/build.gradle
+++ b/producer_with_latest_2_2_features/build.gradle
@@ -21,10 +21,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}], Contract version [${findProperty('verifierVersion') ?: verifierVersion}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}], Contract version [${verifierVersion}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/producer_with_latest_2_2_features/settings.gradle
+++ b/producer_with_latest_2_2_features/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'org.springframework.cloud.contract' version verifierVersion
+	}
+}
+
 rootProject.name = 'beer-api-producer-latest-22'

--- a/producer_with_latest_3_0_features_gradle/build.gradle
+++ b/producer_with_latest_3_0_features_gradle/build.gradle
@@ -1,27 +1,12 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		//remove::start[]
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${findProperty('verifierVersion') ?: verifierVersion}"
-		// remove::end[]
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	//remove::start[]
+	id 'org.springframework.cloud.contract'
+	//remove::end[]
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-//remove::start[]
-apply plugin: 'org.springframework.cloud.contract'
-// remove::end[]
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/producer_with_latest_3_0_features_gradle/build.gradle
+++ b/producer_with_latest_3_0_features_gradle/build.gradle
@@ -21,10 +21,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}], Contract version [${findProperty('verifierVersion') ?: verifierVersion}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}], Contract version [${verifierVersion}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/producer_with_latest_3_0_features_gradle/settings.gradle
+++ b/producer_with_latest_3_0_features_gradle/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'org.springframework.cloud.contract' version verifierVersion
+	}
+}
+
 rootProject.name = 'beer-api-producer-latest-30'

--- a/producer_with_restdocs/build.gradle
+++ b/producer_with_restdocs/build.gradle
@@ -1,27 +1,12 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		//remove::start[]
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${findProperty('verifierVersion') ?: verifierVersion}"
-		// remove::end[]
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	//remove::start[]
+	id 'org.springframework.cloud.contract'
+	//remove::end[]
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-//remove::start[]
-apply plugin: 'spring-cloud-contract'
-// remove::end[]
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/producer_with_restdocs/build.gradle
+++ b/producer_with_restdocs/build.gradle
@@ -21,10 +21,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}], Contract version [${findProperty('verifierVersion') ?: verifierVersion}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}], Contract version [${verifierVersion}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/producer_with_restdocs/settings.gradle
+++ b/producer_with_restdocs/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'org.springframework.cloud.contract' version verifierVersion
+	}
+}
+
 rootProject.name = 'beer-api-producer-restdocs'

--- a/producer_with_spock/build.gradle
+++ b/producer_with_spock/build.gradle
@@ -21,10 +21,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}], Contract version [${findProperty('verifierVersion') ?: verifierVersion}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}], Contract version [${verifierVersion}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/producer_with_spock/build.gradle
+++ b/producer_with_spock/build.gradle
@@ -1,28 +1,12 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		//remove::start[]
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${findProperty('verifierVersion') ?: verifierVersion}"
-		classpath "com.example:beer-common:0.0.1-SNAPSHOT"
-		// remove::end[]
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	//remove::start[]
+	id 'org.springframework.cloud.contract'
+	//remove::end[]
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-//remove::start[]
-apply plugin: 'spring-cloud-contract'
-// remove::end[]
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/producer_with_spock/settings.gradle
+++ b/producer_with_spock/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'org.springframework.cloud.contract' version verifierVersion
+	}
+}
+
 rootProject.name = 'beer-api-producer-with-spock'

--- a/producer_with_stubs_per_consumer/build.gradle
+++ b/producer_with_stubs_per_consumer/build.gradle
@@ -21,10 +21,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/producer_with_stubs_per_consumer/build.gradle
+++ b/producer_with_stubs_per_consumer/build.gradle
@@ -1,28 +1,12 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		//remove::start[]
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${findProperty('verifierVersion') ?: verifierVersion}"
-		classpath "com.example:beer-common:0.0.1-SNAPSHOT"
-		// remove::end[]
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	//remove::start[]
+	id 'org.springframework.cloud.contract'
+	//remove::end[]
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-//remove::start[]
-apply plugin: 'spring-cloud-contract'
-// remove::end[]
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/producer_with_stubs_per_consumer/settings.gradle
+++ b/producer_with_stubs_per_consumer/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'org.springframework.cloud.contract' version verifierVersion
+	}
+}
+
 rootProject.name = 'beer-api-producer-with-stubs-per-consumer'

--- a/producer_with_webtestclient_restdocs/build.gradle
+++ b/producer_with_webtestclient_restdocs/build.gradle
@@ -21,10 +21,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}], Contract version [${findProperty('verifierVersion') ?: verifierVersion}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}], Contract version [${verifierVersion}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-webflux")

--- a/producer_with_webtestclient_restdocs/build.gradle
+++ b/producer_with_webtestclient_restdocs/build.gradle
@@ -1,27 +1,12 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		//remove::start[]
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${findProperty('verifierVersion') ?: verifierVersion}"
-		// remove::end[]
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	//remove::start[]
+	id 'org.springframework.cloud.contract'
+	//remove::end[]
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-//remove::start[]
-apply plugin: 'spring-cloud-contract'
-// remove::end[]
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/producer_with_webtestclient_restdocs/settings.gradle
+++ b/producer_with_webtestclient_restdocs/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'org.springframework.cloud.contract' version verifierVersion
+	}
+}
+
 rootProject.name = 'beer-api-producer-webtestclient-restdocs'

--- a/producer_with_xml/build.gradle
+++ b/producer_with_xml/build.gradle
@@ -1,27 +1,12 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		//remove::start[]
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${findProperty('verifierVersion') ?: verifierVersion}"
-		// remove::end[]
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	//remove::start[]
+	id 'org.springframework.cloud.contract'
+	//remove::end[]
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-//remove::start[]
-apply plugin: 'spring-cloud-contract'
-// remove::end[]
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/producer_with_xml/build.gradle
+++ b/producer_with_xml/build.gradle
@@ -21,10 +21,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}], Contract version [${findProperty('verifierVersion') ?: verifierVersion}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}], Contract version [${verifierVersion}]"
 
 boolean oldProducerTrainEnabled = project.findProperty('OLD_PRODUCER_TRAIN') == "true"
 

--- a/producer_with_xml/settings.gradle
+++ b/producer_with_xml/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'org.springframework.cloud.contract' version verifierVersion
+	}
+}
+
 rootProject.name = 'beer-api-producer-xml'

--- a/producer_yaml/build.gradle
+++ b/producer_yaml/build.gradle
@@ -1,27 +1,12 @@
-buildscript {
-	repositories {
-		mavenCentral()
-		mavenLocal()
-		maven { url "https://repo.spring.io/snapshot" }
-		maven { url "https://repo.spring.io/milestone" }
-		maven { url "https://repo.spring.io/release" }
-	}
-	dependencies {
-		classpath "org.springframework.boot:spring-boot-gradle-plugin:${findProperty('bootVersion') ?: bootVersion}"
-		//remove::start[]
-		classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:${findProperty('verifierVersion') ?: verifierVersion}"
-		// remove::end[]
-		classpath "io.spring.gradle:dependency-management-plugin:1.0.10.RELEASE"
-	}
+plugins {
+	id 'groovy'
+	id 'org.springframework.boot'
+	id 'io.spring.dependency-management'
+	//remove::start[]
+	id 'org.springframework.cloud.contract'
+	//remove::end[]
+	id 'maven-publish'
 }
-
-apply plugin: 'groovy'
-apply plugin: 'org.springframework.boot'
-apply plugin: 'io.spring.dependency-management'
-//remove::start[]
-apply plugin: 'spring-cloud-contract'
-// remove::end[]
-apply plugin: 'maven-publish'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'

--- a/producer_yaml/build.gradle
+++ b/producer_yaml/build.gradle
@@ -21,10 +21,10 @@ repositories {
 }
 
 ext {
-	set('springCloudVersion', "${project.findProperty('BOM_VERSION') ?: BOM_VERSION}")
+	set('springCloudVersion', "${BOM_VERSION}")
 }
 
-println "Boot Version [${findProperty('bootVersion') ?: bootVersion}], Cloud version [${findProperty('BOM_VERSION') ?: BOM_VERSION}], Contract version [${findProperty('verifierVersion') ?: verifierVersion}]"
+println "Boot Version [${bootVersion}], Cloud version [${BOM_VERSION}], Contract version [${verifierVersion}]"
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/producer_yaml/settings.gradle
+++ b/producer_yaml/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url 'https://repo.spring.io/snapshot' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		gradlePluginPortal()
+	}
+	plugins {
+		id 'org.springframework.boot' version bootVersion
+		id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+		id 'org.springframework.cloud.contract' version verifierVersion
+	}
+}
+
 rootProject.name = 'beer-api-producer-yaml'


### PR DESCRIPTION
As of Spring Cloud Contract 3.0, the need for adding additional libraries to the plugin classpath was removed. SCC 3.0 instead relies on the contractTest source set's classpath directly which furthermore reduces the need for doubling up certain dependencies between the Gradle plugin classpath and the application's classpath.